### PR TITLE
Disable buy rounds / bid functions if the base token is PIL.

### DIFF
--- a/contracts/core/facets/AMMFacet.sol
+++ b/contracts/core/facets/AMMFacet.sol
@@ -275,6 +275,7 @@ contract AMMFacet is Modifiers {
         uint128 _roundFee
     ) private {
         address baseToken = LibGetters._getPairInfo(_metaNftId).baseToken;
+        require(baseToken != s.pil, "PIL trading is temporary disabled"); // TODO: Remove after PIL migration
         uint256 beforeBalance = IERC20(baseToken).balanceOf(address(this));
 
         /// Transfer base tokens from the caller.

--- a/contracts/core/facets/ListingFacet.sol
+++ b/contracts/core/facets/ListingFacet.sol
@@ -393,6 +393,7 @@ contract ListingFacet is Modifiers {
         uint64 _expiry
     ) {
         PairInfo storage pairInfo = LibGetters._getPairInfo(_bidArgs._metaNftId);
+        require(pairInfo.baseToken != s.pil, "PIL trading is temporary disabled"); // TODO: Remove after PIL migration
         require(msg.sender != IPilgrimMetaNFT(s.metaNFT).ownerOf(pairInfo.metaNftId));
 
         mapping(address => BidInfo) storage bidInfo = _bidArgs._isNft ? pairInfo.nftInfo : pairInfo.metaNftInfo;

--- a/test/core/01_AMMFacet/06_buyRoundsWithExactBases.test.ts
+++ b/test/core/01_AMMFacet/06_buyRoundsWithExactBases.test.ts
@@ -1,3 +1,4 @@
+import { expect } from 'chai';
 import {
   BigNumber,
   BigNumberish,
@@ -14,7 +15,7 @@ import {
   ManagingFacet,
   ERC20Mock,
   ERC721Mock,
-  PilgrimMetaNFT,
+  PilgrimMetaNFT, PilgrimToken,
 } from '../../../typechain';
 import {
   afterRoundFee,
@@ -30,6 +31,7 @@ import {
   tenPercent,
   zeroEther,
 } from '../../testUtils';
+
 
 describe('buyRoundsWithExactBases', function () {
   let admin: Signer;
@@ -51,6 +53,7 @@ describe('buyRoundsWithExactBases', function () {
 
   let core: Diamond;
   let pilgrimMetaNFT: PilgrimMetaNFT;
+  let pilgrim: PilgrimToken;
 
   let aMMFacet: AMMFacet;
   let listingFacet: ListingFacet;
@@ -59,7 +62,7 @@ describe('buyRoundsWithExactBases', function () {
 
   this.beforeEach(async function () {
     // @ts-ignore
-    ({ core, pilgrimMetaNFT, testERC20 } = await deployAll());
+    ({ core, pilgrimMetaNFT, testERC20, pilgrim } = await deployAll());
 
     aMMFacet = await ethers.getContractAt('AMMFacet', core.address);
     listingFacet = await ethers.getContractAt('ListingFacet', core.address);
@@ -88,6 +91,30 @@ describe('buyRoundsWithExactBases', function () {
     await testERC20.connect(admin).transfer(user4Addr, oneEther.mul(100_000));
     await testERC20.connect(admin).transfer(user5Addr, oneEther.mul(100_000));
     await managingFacet.createPool(testERC20.address, 1, 0);
+  });
+
+  it('CORE_TEMP_02', async function (): Promise<void> {
+    await managingFacet.createPool(pilgrim.address, 1, 0);
+
+    const tags: string[] = [];
+    const listResult = await runRWMethod({
+      method: listingFacet
+        .connect(user1)
+        .list(testERC721.address, tokenId, listingPrice, pilgrim.address, tags, dummyIpfsHash),
+      name: 'List',
+    });
+
+    const metaNftId: BigNumberish = listResult._metaNftId;
+    const expectedRoundOut: BigNumber = oneEther.mul(9); // TODO
+    const desiredBaseIn: BigNumber = oneEther.mul(10);
+
+    const method = aMMFacet.connect(user1).buyRoundsWithExactBases(
+      metaNftId,
+      desiredBaseIn,
+      expectedRoundOut,
+      deadline,
+    );
+    await expect(method).to.be.revertedWith('PIL trading is temporary disabled');
   });
 
   // Buy when just listed

--- a/test/core/02_ListingFacet/10_bidNFT.test.ts
+++ b/test/core/02_ListingFacet/10_bidNFT.test.ts
@@ -14,7 +14,7 @@ import {
   ManagingFacet,
   ERC20Mock,
   ERC721Mock,
-  PilgrimMetaNFT,
+  PilgrimMetaNFT, PilgrimToken,
 } from '../../../typechain';
 import {
   afterRoundFee,
@@ -58,6 +58,7 @@ describe('bidNFT', function () {
 
   let core: Diamond;
   let pilgrimMetaNFT: PilgrimMetaNFT;
+  let pilgrim: PilgrimToken;
 
   let aMMFacet: AMMFacet;
   let listingFacet: ListingFacet;
@@ -66,7 +67,7 @@ describe('bidNFT', function () {
 
   this.beforeEach(async function () {
     // @ts-ignore
-    ({ core, pilgrimMetaNFT, testERC20 } = await deployAll());
+    ({ core, pilgrimMetaNFT, testERC20, pilgrim } = await deployAll());
 
     aMMFacet = await ethers.getContractAt('AMMFacet', core.address);
     listingFacet = await ethers.getContractAt('ListingFacet', core.address);
@@ -95,6 +96,31 @@ describe('bidNFT', function () {
     await testERC20.connect(admin).transfer(user4Addr, oneEther.mul(100_000));
     await testERC20.connect(admin).transfer(user5Addr, oneEther.mul(100_000));
     await managingFacet.createPool(testERC20.address, 1, 0);
+  });
+
+  it('CORE_TEMP_03', async function (): Promise<void> {
+    await managingFacet.createPool(pilgrim.address, 1, 0);
+
+    const listReulst = await runRWMethod({
+      method: listingFacet.connect(user1).list(
+        testERC721.address,
+        tokenId,
+        listingPrice,
+        pilgrim.address,
+        emptyTagArr,
+        dummyIpfsHash,
+      ),
+      name: 'List',
+    });
+
+    const metaNftId: BigNumberish = listReulst._metaNftId;
+
+    const method = listingFacet.connect(user2).bidNft(
+      metaNftId,
+      beforeNftFee(g0NFT),
+      deadline,
+    );
+    await expect(method).to.be.revertedWith('PIL trading is temporary disabled');
   });
 
   // Bid when just listed


### PR DESCRIPTION
We need to disable PIL related trading such as buying rounds & bidding NFT(or MetaNFT).
These facets will temporarily replace current facets until PIL token migration is done.

This PR won't be merged